### PR TITLE
Increase RRD-Timeout to 10 minutes to avoid unknown data

### DIFF
--- a/GlobalRRD.py
+++ b/GlobalRRD.py
@@ -5,9 +5,9 @@ from RRD import RRD, DS, RRA
 class GlobalRRD(RRD):
     ds_list = [
         # Number of nodes available
-        DS('nodes', 'GAUGE', 120, 0, float('NaN')),
+        DS('nodes', 'GAUGE', 600, 0, float('NaN')),
         # Number of client available
-        DS('clients', 'GAUGE', 120, 0, float('NaN')),
+        DS('clients', 'GAUGE', 600, 0, float('NaN')),
     ]
     rra_list = [
         RRA('AVERAGE', 0.5, 1, 120),    #  2 hours of 1 minute samples

--- a/NodeRRD.py
+++ b/NodeRRD.py
@@ -5,8 +5,8 @@ from RRD import RRD, DS, RRA
 
 class NodeRRD(RRD):
     ds_list = [
-        DS('upstate', 'GAUGE', 120, 0, 1),
-        DS('clients', 'GAUGE', 120, 0, float('NaN')),
+        DS('upstate', 'GAUGE', 600, 0, 1),
+        DS('clients', 'GAUGE', 600, 0, float('NaN')),
     ]
     rra_list = [
         RRA('AVERAGE', 0.5, 1, 120),    #  2 hours of  1 minute samples


### PR DESCRIPTION
The default rrd configuration expects new values every 60 seconds and will record "UNKNOWN" after 120 seconds, however the README suggests to run the script every 5 minutes. Since this is longer than the RRD heartbeat interval every rrd will only record unknown/offline and not the desired  node statistics.

I suggest this change to increase the RRD heartbeat (=timeout) to 10 minutes - too frequent updates may cause performance issues. More frequent RRAs are still in place so the community can still use faster updates if desired. as an alternative, I would suggest to change the readme so cron will call the script every minute instead of every 5 minutes.
